### PR TITLE
Add support for more unlimited fields on export of Matrix Field

### DIFF
--- a/migrationmanager/services/MigrationManager_BaseContentMigrationService.php
+++ b/migrationmanager/services/MigrationManager_BaseContentMigrationService.php
@@ -39,6 +39,7 @@ abstract class MigrationManager_BaseContentMigrationService extends MigrationMan
                     break;
                 case 'Matrix':
                     $model = $parent[$field->handle];
+                    $model->limit = null;
                     $value = $this->getIteratorValues($model, function ($item) {
                         $itemType = $item->getType();
                         $value = [


### PR DESCRIPTION
When performing an export, not all content within a matrix field is included.

**Expected behaviour**: All content within a matrix field is included.

Fixed by adding `null` as limit.